### PR TITLE
ci: run `rustfmt` with `--check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           channel: nightly
           components: rustfmt
-      - run: make format
+      - run: make format-check
 
   docs:
     name: Documentation

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ lint:
 format:
 	cargo +nightly fmt --all
 
+format-check:
+	cargo +nightly fmt --all --check
+
 docs:
 	cargo doc --all-features --workspace --document-private-items --no-deps
 


### PR DESCRIPTION
We don't actually want to format any files in CI; just check if they're formatted properly.
