### PR TITLE
refactor: improve OpenAPI docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,4 @@ features = ["macros", "rust_decimal", "chrono", "runtime-tokio", "tls-rustls", "
 
 [workspace.dependencies.utoipa]
 version = "4"
-features = ["chrono", "axum_extras"]
+features = ["chrono", "axum_extras", "preserve_order", "preserve_path_order", "non_strict_integers"]

--- a/cs2kz-api/src/headers.rs
+++ b/cs2kz-api/src/headers.rs
@@ -1,6 +1,7 @@
 use axum::http::{HeaderName, HeaderValue};
 use axum_extra::headers::{self, Header};
 use serde::Deserialize;
+use utoipa::IntoParams;
 
 #[derive(Debug, Deserialize)]
 pub struct ApiKey(pub u32);
@@ -23,6 +24,41 @@ impl Header for ApiKey {
 			.to_str()
 			.map_err(|_| headers::Error::invalid())?
 			.parse::<u32>()
+			.map_err(|_| headers::Error::invalid())?;
+
+		Ok(Self(value))
+	}
+
+	fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+		let s = self.0.to_string();
+		let value = HeaderValue::from_str(&s).expect("u32 is valid ASCII");
+
+		values.extend(std::iter::once(value));
+	}
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(names("plugin-version"), parameter_in = Header)]
+pub struct PluginVersion(pub u16);
+
+static PLUGIN_VERSION_HEADER_NAME: HeaderName = HeaderName::from_static("plugin-version");
+
+impl Header for PluginVersion {
+	fn name() -> &'static HeaderName {
+		&PLUGIN_VERSION_HEADER_NAME
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		Self: Sized,
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values
+			.next()
+			.ok_or_else(headers::Error::invalid)?
+			.to_str()
+			.map_err(|_| headers::Error::invalid())?
+			.parse::<u16>()
 			.map_err(|_| headers::Error::invalid())?;
 
 		Ok(Self(value))

--- a/cs2kz-api/src/middleware/auth/gameservers.rs
+++ b/cs2kz-api/src/middleware/auth/gameservers.rs
@@ -5,16 +5,11 @@ use axum_extra::headers::authorization::Bearer;
 use axum_extra::headers::Authorization;
 use axum_extra::TypedHeader;
 use jsonwebtoken as jwt;
-use serde::Deserialize;
 
 use super::jwt::GameServerInfo;
+use crate::headers::PluginVersion;
 use crate::state::JwtState;
-use crate::{middleware, Error, Result, State};
-
-#[derive(Debug, Deserialize)]
-struct ServerMetadata {
-	plugin_version: u16,
-}
+use crate::{Error, Result, State};
 
 #[derive(Debug, Clone)]
 pub struct AuthenticatedServer {
@@ -26,7 +21,8 @@ pub struct AuthenticatedServer {
 pub async fn auth_server(
 	state: State,
 	api_token: TypedHeader<Authorization<Bearer>>,
-	request: Request,
+	plugin_version: TypedHeader<PluginVersion>,
+	mut request: Request,
 	next: Next,
 ) -> Result<Response> {
 	let JwtState { decode, validation, .. } = state.jwt();
@@ -36,15 +32,9 @@ pub async fn auth_server(
 		return Err(Error::Unauthorized);
 	}
 
-	let (metadata, mut request) = middleware::deserialize_body::<ServerMetadata>(request).await?;
+	let metadata = AuthenticatedServer { id, plugin_version: plugin_version.0.0 };
 
-	let Some(ServerMetadata { plugin_version }) = metadata else {
-		return Err(Error::InvalidRequestBody);
-	};
-
-	request
-		.extensions_mut()
-		.insert(AuthenticatedServer { id, plugin_version });
+	request.extensions_mut().insert(metadata);
 
 	Ok(next.run(request).await)
 }

--- a/cs2kz-api/src/routes/auth.rs
+++ b/cs2kz-api/src/routes/auth.rs
@@ -15,13 +15,13 @@ use crate::{Error, Result, State};
 ///
 /// This endpoint is used by CS2 game servers to refresh their access token.
 #[tracing::instrument(skip(state))]
-#[utoipa::path(get, tag = "Auth", context_path = "/api", path = "/auth/token", params(
-	("api-key" = u32, Header, description = "API Key"),
-), responses(
+#[utoipa::path(get, tag = "Auth", context_path = "/api", path = "/auth/token", responses(
 	responses::Ok<()>,
 	responses::BadRequest,
 	responses::Unauthorized,
 	responses::InternalServerError,
+), security(
+	("API Key" = []),
 ))]
 pub async fn token(state: State, TypedHeader(ApiKey(api_key)): TypedHeader<ApiKey>) -> Result<()> {
 	let server = sqlx::query! {

--- a/cs2kz-api/src/routes/bans.rs
+++ b/cs2kz-api/src/routes/bans.rs
@@ -9,6 +9,7 @@ use sqlx::QueryBuilder;
 use utoipa::{IntoParams, ToSchema};
 
 use super::{BoundedU64, Filter};
+use crate::headers::PluginVersion;
 use crate::middleware::auth::gameservers::AuthenticatedServer;
 use crate::res::bans::{self as res, BanReason};
 use crate::res::{responses, Created};
@@ -220,6 +221,7 @@ pub struct CreatedBan {
 
 #[tracing::instrument(skip(state))]
 #[utoipa::path(post, tag = "Bans", context_path = "/api", path = "/bans",
+	params(PluginVersion),
 	request_body = NewBan,
 	responses(
 		responses::Created<CreatedBan>,
@@ -227,6 +229,7 @@ pub struct CreatedBan {
 		responses::Unauthorized,
 		responses::InternalServerError,
 	),
+	security(("API Token" = [])),
 )]
 pub async fn create_ban(
 	state: State,

--- a/cs2kz-api/src/routes/maps.rs
+++ b/cs2kz-api/src/routes/maps.rs
@@ -469,7 +469,7 @@ pub struct FilterWithCourseId {
 }
 
 #[tracing::instrument(skip(state))]
-#[utoipa::path(put, tag = "Maps", context_path = "/api", path = "/maps/{id}",
+#[utoipa::path(patch, tag = "Maps", context_path = "/api", path = "/maps/{id}",
 	params(("id" = u16, Path, description = "The map's ID")),
 	request_body = MapUpdate,
 	responses(

--- a/cs2kz-api/src/routes/players.rs
+++ b/cs2kz-api/src/routes/players.rs
@@ -8,6 +8,7 @@ use sqlx::QueryBuilder;
 use utoipa::{IntoParams, ToSchema};
 
 use super::{BoundedU64, Filter};
+use crate::headers::PluginVersion;
 use crate::middleware::auth::gameservers::AuthenticatedServer;
 use crate::res::{player as res, responses, Created};
 use crate::{database, Error, Result, State};
@@ -167,6 +168,7 @@ pub struct NewPlayer {
 
 #[tracing::instrument(skip(state))]
 #[utoipa::path(post, tag = "Players", context_path = "/api", path = "/players",
+	params(PluginVersion),
 	request_body = NewPlayer,
 	responses(
 		responses::Created<()>,
@@ -174,6 +176,7 @@ pub struct NewPlayer {
 		responses::Unauthorized,
 		responses::InternalServerError,
 	),
+	security(("API Token" = [])),
 )]
 pub async fn create_player(
 	state: State,
@@ -252,8 +255,11 @@ pub struct SessionData {
 }
 
 #[tracing::instrument(skip(state))]
-#[utoipa::path(put, tag = "Players", context_path = "/api", path = "/players/{steam_id}",
-	params(("steam_id" = SteamID, Path, description = "The player's SteamID")),
+#[utoipa::path(patch, tag = "Players", context_path = "/api", path = "/players/{steam_id}",
+	params(
+		PluginVersion,
+		("steam_id" = SteamID, Path, description = "The player's SteamID")
+	),
 	request_body = PlayerUpdate,
 	responses(
 		responses::Ok<()>,
@@ -261,6 +267,7 @@ pub struct SessionData {
 		responses::Unauthorized,
 		responses::InternalServerError,
 	),
+	security(("API Token" = [])),
 )]
 pub async fn update_player(
 	state: State,

--- a/cs2kz-api/src/routes/records.rs
+++ b/cs2kz-api/src/routes/records.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
 use super::BoundedU64;
+use crate::headers::PluginVersion;
 use crate::middleware::auth::gameservers::AuthenticatedServer;
 use crate::res::{records as res, responses, Created};
 use crate::{Error, Result, State};
@@ -215,6 +216,7 @@ pub struct CreatedRecord {
 
 #[tracing::instrument(skip(state))]
 #[utoipa::path(post, tag = "Records", context_path = "/api", path = "/records",
+	params(PluginVersion),
 	request_body = NewRecord,
 	responses(
 		responses::Created<CreatedRecord>,
@@ -222,6 +224,7 @@ pub struct CreatedRecord {
 		responses::Unauthorized,
 		responses::InternalServerError,
 	),
+	security(("API Token" = [])),
 )]
 pub async fn create_record(
 	state: State,

--- a/cs2kz-api/src/routes/servers.rs
+++ b/cs2kz-api/src/routes/servers.rs
@@ -246,7 +246,7 @@ pub struct ServerUpdate {
 }
 
 #[tracing::instrument(skip(state))]
-#[utoipa::path(put, tag = "Servers", context_path = "/api", path = "/servers/{id}",
+#[utoipa::path(patch, tag = "Servers", context_path = "/api", path = "/servers/{id}",
 	params(("id" = u16, Path, description = "The server's ID")),
 	request_body = ServerUpdate,
 	responses(


### PR DESCRIPTION
- Change `PUT` requests to `PATCH` as they are all partial updates
- Move `plugin-version` from request body to its own header
- Include authentication in the OpenAPI docs
