### PR TITLE
Custom attribute macro for test functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "cs2kz",
+ "cs2kz-api-macros",
  "ctor",
  "dotenvy",
  "itertools",
@@ -538,6 +539,16 @@ dependencies = [
  "url",
  "utoipa",
  "utoipa-swagger-ui",
+]
+
+[[package]]
+name = "cs2kz-api-macros"
+version = "0.0.0"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["cs2kz", "cs2kz-api", "spec-generator"]
+members = ["cs2kz", "cs2kz-api", "spec-generator", "macros"]
 
 [workspace.dependencies.dotenvy]
 version = "0.15"

--- a/cs2kz-api/Cargo.toml
+++ b/cs2kz-api/Cargo.toml
@@ -65,3 +65,4 @@ version = "0.12"
 
 [dev-dependencies]
 ctor = "0.2.6"
+cs2kz-api-macros = { path = "../macros" }

--- a/cs2kz-api/src/lib.rs
+++ b/cs2kz-api/src/lib.rs
@@ -6,6 +6,10 @@
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+#[rustfmt::skip]
+pub(crate) use cs2kz_api_macros::test;
+
 use std::fmt::Write;
 use std::net::SocketAddr;
 

--- a/cs2kz-api/src/tests/maps.rs
+++ b/cs2kz-api/src/tests/maps.rs
@@ -37,6 +37,4 @@ async fn get(ctx: Context) {
 		steam_id: SteamID::from_u32(117087881)?,
 		name: String::from("Kiwi"),
 	}]);
-
-	Ok(())
 }

--- a/cs2kz-api/src/tests/maps.rs
+++ b/cs2kz-api/src/tests/maps.rs
@@ -1,24 +1,13 @@
 use color_eyre::eyre::ContextCompat;
-use color_eyre::Result;
 use cs2kz::SteamID;
-use sqlx::MySqlPool;
 
-use super::Context;
 use crate::models::{KZMap, Player};
 
-#[sqlx::test(
-	migrator = "super::MIGRATOR",
-	fixtures(
-		path = "../../../database/fixtures",
-		scripts("players.sql", "maps.sql"),
-	)
-)]
-async fn get(pool: MySqlPool) -> Result<()> {
-	let cx = Context::new(pool).await?;
-
-	let all_maps = cx
+#[crate::test("players.sql", "maps.sql")]
+async fn get(ctx: Context) -> Result<()> {
+	let all_maps = ctx
 		.client
-		.get(cx.url("/maps"))
+		.get(ctx.url("/maps"))
 		.send()
 		.await?
 		.json::<Vec<KZMap>>()
@@ -26,9 +15,9 @@ async fn get(pool: MySqlPool) -> Result<()> {
 
 	assert_eq!(all_maps.len(), 2, "incorrect amount of maps: {all_maps:#?}");
 
-	let victoria = cx
+	let victoria = ctx
 		.client
-		.get(cx.url("/maps/victoria"))
+		.get(ctx.url("/maps/victoria"))
 		.send()
 		.await?
 		.json::<KZMap>()

--- a/cs2kz-api/src/tests/maps.rs
+++ b/cs2kz-api/src/tests/maps.rs
@@ -4,7 +4,7 @@ use cs2kz::SteamID;
 use crate::models::{KZMap, Player};
 
 #[crate::test("players.sql", "maps.sql")]
-async fn get(ctx: Context) -> Result<()> {
+async fn get(ctx: Context) {
 	let all_maps = ctx
 		.client
 		.get(ctx.url("/maps"))

--- a/cs2kz-api/src/tests/mod.rs
+++ b/cs2kz-api/src/tests/mod.rs
@@ -1,16 +1,9 @@
 use std::fmt::Display;
 use std::net::SocketAddr;
 
-use color_eyre::eyre::eyre;
-use color_eyre::Result;
 use ctor::ctor;
 use sqlx::migrate::Migrator;
-use sqlx::MySqlPool;
-use tokio::net::TcpListener;
-use tokio::task;
 use tracing_subscriber::EnvFilter;
-
-use crate::{Config, API};
 
 mod status;
 mod players;
@@ -44,31 +37,6 @@ struct Context {
 }
 
 impl Context {
-	/// Creates a new test context.
-	async fn new(database: MySqlPool) -> Result<Self> {
-		let tcp_listener = TcpListener::bind("127.0.0.1:0").await?;
-		let addr = tcp_listener.local_addr()?;
-		let ctx = Self { client: reqwest::Client::new(), addr };
-		let mut config = Config::new().await?;
-
-		config.socket_addr.set_port(addr.port());
-		config
-			.api_url
-			.set_port(Some(addr.port()))
-			.map_err(|_| eyre!("Failed to set API port."))?;
-
-		// Run the API in the background.
-		task::spawn(async move {
-			API::run(config, database, tcp_listener)
-				.await
-				.expect("Failed to run API.");
-
-			unreachable!("API shutdown prematurely.");
-		});
-
-		Ok(ctx)
-	}
-
 	/// Utility method for constructing a request URL to this test's API instance.
 	fn url(&self, path: impl Display) -> String {
 		format!("http://{}{}", self.addr, path)

--- a/cs2kz-api/src/tests/players.rs
+++ b/cs2kz-api/src/tests/players.rs
@@ -1,7 +1,7 @@
 use crate::models::Player;
 
 #[crate::test("players.sql")]
-async fn get(ctx: Context) -> Result<()> {
+async fn get(ctx: Context) {
 	let all_players = ctx
 		.client
 		.get(ctx.url("/players"))

--- a/cs2kz-api/src/tests/players.rs
+++ b/cs2kz-api/src/tests/players.rs
@@ -50,6 +50,4 @@ async fn get(ctx: Context) {
 
 	assert_eq!(zer0k.steam_id.as_u32(), 158416176);
 	assert_eq!(zer0k.name, "zer0.k");
-
-	Ok(())
 }

--- a/cs2kz-api/src/tests/players.rs
+++ b/cs2kz-api/src/tests/players.rs
@@ -1,19 +1,10 @@
-use color_eyre::Result;
-use sqlx::MySqlPool;
-
-use super::Context;
 use crate::models::Player;
 
-#[sqlx::test(
-	migrator = "super::MIGRATOR",
-	fixtures(path = "../../../database/fixtures", scripts("players.sql"))
-)]
-async fn get(pool: MySqlPool) -> Result<()> {
-	let cx = Context::new(pool).await?;
-
-	let all_players = cx
+#[crate::test("players.sql")]
+async fn get(ctx: Context) -> Result<()> {
+	let all_players = ctx
 		.client
-		.get(cx.url("/players"))
+		.get(ctx.url("/players"))
 		.send()
 		.await?
 		.json::<Vec<Player>>()
@@ -27,9 +18,9 @@ async fn get(pool: MySqlPool) -> Result<()> {
 
 	assert!(has_ibrahizy, "missing iBrahizy");
 
-	let ibrahizy = cx
+	let ibrahizy = ctx
 		.client
-		.get(cx.url("/players/304674089"))
+		.get(ctx.url("/players/304674089"))
 		.send()
 		.await?
 		.json::<Player>()
@@ -38,9 +29,9 @@ async fn get(pool: MySqlPool) -> Result<()> {
 	assert_eq!(ibrahizy.steam_id.as_u32(), 304674089);
 	assert_eq!(ibrahizy.name, "iBrahizy");
 
-	let alphakeks = cx
+	let alphakeks = ctx
 		.client
-		.get(cx.url("/players/STEAM_1:1:161178172"))
+		.get(ctx.url("/players/STEAM_1:1:161178172"))
 		.send()
 		.await?
 		.json::<Player>()
@@ -49,9 +40,9 @@ async fn get(pool: MySqlPool) -> Result<()> {
 	assert_eq!(alphakeks.steam_id.as_u32(), 322356345);
 	assert_eq!(alphakeks.name, "AlphaKeks");
 
-	let zer0k = cx
+	let zer0k = ctx
 		.client
-		.get(cx.url("/players/er0."))
+		.get(ctx.url("/players/er0."))
 		.send()
 		.await?
 		.json::<Player>()

--- a/cs2kz-api/src/tests/servers.rs
+++ b/cs2kz-api/src/tests/servers.rs
@@ -1,25 +1,14 @@
 use std::net::Ipv4Addr;
 
-use color_eyre::Result;
 use cs2kz::SteamID;
-use sqlx::MySqlPool;
 
-use super::Context;
 use crate::models::{Player, Server};
 
-#[sqlx::test(
-	migrator = "super::MIGRATOR",
-	fixtures(
-		path = "../../../database/fixtures",
-		scripts("players.sql", "servers.sql"),
-	)
-)]
-async fn get(pool: MySqlPool) -> Result<()> {
-	let cx = Context::new(pool).await?;
-
-	let all_servers = cx
+#[crate::test("players.sql", "servers.sql")]
+async fn get(ctx: Context) -> Result<()> {
+	let all_servers = ctx
 		.client
-		.get(cx.url("/servers"))
+		.get(ctx.url("/servers"))
 		.send()
 		.await?
 		.json::<Vec<Server>>()
@@ -27,9 +16,9 @@ async fn get(pool: MySqlPool) -> Result<()> {
 
 	assert_eq!(all_servers.len(), 1, "incorrect amount of servers: {all_servers:#?}");
 
-	let alphas_kz = cx
+	let alphas_kz = ctx
 		.client
-		.get(cx.url("/servers/alpha"))
+		.get(ctx.url("/servers/alpha"))
 		.send()
 		.await?
 		.json::<Server>()

--- a/cs2kz-api/src/tests/servers.rs
+++ b/cs2kz-api/src/tests/servers.rs
@@ -5,7 +5,7 @@ use cs2kz::SteamID;
 use crate::models::{Player, Server};
 
 #[crate::test("players.sql", "servers.sql")]
-async fn get(ctx: Context) -> Result<()> {
+async fn get(ctx: Context) {
 	let all_servers = ctx
 		.client
 		.get(ctx.url("/servers"))

--- a/cs2kz-api/src/tests/servers.rs
+++ b/cs2kz-api/src/tests/servers.rs
@@ -32,6 +32,4 @@ async fn get(ctx: Context) {
 		steam_id: SteamID::from_u32(322356345)?,
 		name: String::from("AlphaKeks"),
 	});
-
-	Ok(())
 }

--- a/cs2kz-api/src/tests/status.rs
+++ b/cs2kz-api/src/tests/status.rs
@@ -3,6 +3,4 @@ async fn basic(ctx: Context) {
 	let schnose = ctx.client.get(ctx.url("/")).send().await?.text().await?;
 
 	assert_eq!(schnose, "(͡ ͡° ͜ つ ͡͡°)");
-
-	Ok(())
 }

--- a/cs2kz-api/src/tests/status.rs
+++ b/cs2kz-api/src/tests/status.rs
@@ -1,12 +1,6 @@
-use color_eyre::Result;
-use sqlx::MySqlPool;
-
-use super::Context;
-
-#[sqlx::test]
-async fn basic(pool: MySqlPool) -> Result<()> {
-	let cx = Context::new(pool).await?;
-	let schnose = cx.client.get(cx.url("/")).send().await?.text().await?;
+#[crate::test]
+async fn basic(ctx: Context) -> Result<()> {
+	let schnose = ctx.client.get(ctx.url("/")).send().await?.text().await?;
 
 	assert_eq!(schnose, "(͡ ͡° ͜ つ ͡͡°)");
 

--- a/cs2kz-api/src/tests/status.rs
+++ b/cs2kz-api/src/tests/status.rs
@@ -1,5 +1,5 @@
 #[crate::test]
-async fn basic(ctx: Context) -> Result<()> {
+async fn basic(ctx: Context) {
 	let schnose = ctx.client.get(ctx.url("/")).send().await?.text().await?;
 
 	assert_eq!(schnose, "(͡ ͡° ͜ つ ͡͡°)");

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cs2kz-api-macros"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+proc-macro-error = "1"
+quote = "1"
+syn = { version = "1", features = ["extra-traits"] }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -159,7 +159,7 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
 						addr,
 					};
 
-					if let err @ Err(_) = { #inner_fn } {
+					if let err @ ::color_eyre::Result::Err(_) = { #inner_fn ::color_eyre::Result::Ok(()) } {
 						return err;
 					}
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,174 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{parse_macro_input, AttributeArgs, FnArg, ItemFn, Lit, NestedMeta, Pat, Type};
+
+static FIXTURES_PATH: &str = "./database/fixtures";
+
+macro_rules! error {
+	($item:expr, $($rest:tt)+) => {
+		return ::syn::Error::new($item.span(), format!($($rest)+))
+			.into_compile_error()
+			.into();
+	}
+}
+
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+	let args = parse_macro_input!(args as AttributeArgs);
+	let function = parse_macro_input!(item as ItemFn);
+
+	let mut post_migration_queries = Vec::new();
+
+	for arg in args.into_iter() {
+		let NestedMeta::Lit(Lit::Str(literal)) = arg else {
+			error!(arg, "Invalid attribute argument. Expected list of string literals.");
+		};
+
+		let path = Path::new(FIXTURES_PATH).join(PathBuf::from(literal.value()));
+
+		if !path.extension().is_some_and(|ext| ext == "sql") {
+			error!(literal, "Files are expected to end in `.sql`.");
+		}
+
+		if !path.exists() {
+			error!(literal, "`{path:?}` does not exist.");
+		}
+
+		let queries = fs::read_to_string(path)
+			.unwrap()
+			.split(';')
+			.map(|query| query.trim().to_owned())
+			.filter(|query| !query.is_empty())
+			.collect::<Vec<String>>();
+
+		post_migration_queries.extend(queries);
+	}
+
+	if function.sig.asyncness.is_none() {
+		error!(function.sig, "Test functions must be marked as `async`.");
+	}
+
+	if function.sig.inputs.len() != 1 {
+		error! {
+			function.sig.inputs,
+			"Test functions only accept a single argument of type `Context`."
+		};
+	}
+
+	let argument = function.sig.inputs.first().unwrap();
+
+	let FnArg::Typed(argument) = argument else {
+		error!(argument, "Test functions cannot have a `self` parameter.");
+	};
+
+	if !argument.attrs.is_empty() {
+		error!(argument.attrs[0], "Arguments cannot be annotated.");
+	}
+
+	let Pat::Ident(_argument_identifier) = argument.pat.as_ref() else {
+		error!(argument.pat, "Argument identifiers cannot use pattern matching.");
+	};
+
+	let Type::Path(argument_type) = argument.ty.as_ref() else {
+		error!(argument.ty, "Argument types must be paths.");
+	};
+
+	if !argument_type
+		.path
+		.get_ident()
+		.is_some_and(|ident| ident == "Context")
+	{
+		error!(argument_type.path, "Invalid argument type. Expected `Context`.");
+	}
+
+	let inner_fn = &function.block;
+
+	quote! {
+		#[test]
+		fn balls() -> ::color_eyre::Result<()> {
+			use ::color_eyre::eyre::Context as _;
+			use ::sqlx::migrate::MigrateDatabase as _;
+			use ::std::fmt::Write as _;
+
+			::tokio::runtime::Runtime::new()
+				.context("failed to construct tokio runtime")?
+				.block_on(async move {
+					let tcp_listener = ::tokio::net::TcpListener::bind("127.0.0.1:0")
+						.await
+						.context("failed to bind tcp listener")?;
+
+					let addr = tcp_listener
+						.local_addr()
+						.context("failed to get tcp listener addr")?;
+
+					let port = addr.port();
+
+					let mut database_url =
+						::std::env::var("TEST_DATABASE_URL").context("missing `TEST_DATABASE_URL`")?;
+
+					write!(&mut database_url, "-test-{port}")?;
+
+					::sqlx::mysql::MySql::create_database(&database_url)
+						.await
+						.with_context(|| format!("failed to create test database {port}"))?;
+
+					let database = ::sqlx::mysql::MySqlPoolOptions::new()
+						.connect(&database_url)
+						.await
+						.context("failed to connect to database")?;
+
+					crate::tests::MIGRATOR
+						.run(&database)
+						.await
+						.with_context(|| format!("failed to run migrations for {port}"))?;
+
+					#(
+						::sqlx::query!(#post_migration_queries)
+							.execute(&database)
+							.await
+							.context("failed to execute post-migration script")?;
+					)*
+
+					let mut config = crate::Config::new()
+						.await
+						.context("failed to load API configuration")?;
+
+					config.socket_addr.set_port(port);
+					config
+						.api_url
+						.set_port(Some(port))
+						.map_err(|_| ::color_eyre::eyre::eyre!("failed to set API port"))?;
+
+					::tokio::task::spawn(async move {
+						crate::API::run(config, database, tcp_listener)
+							.await
+							.expect("Failed to run API.");
+
+						unreachable!("API shutdown prematurely.");
+					});
+
+					let ctx = crate::tests::Context {
+						client: ::reqwest::Client::new(),
+						addr,
+					};
+
+					if let err @ Err(_) = { #inner_fn } {
+						return err;
+					}
+
+					::sqlx::mysql::MySql::drop_database(&database_url)
+						.await
+						.with_context(|| format!("failed to drop test database {port}"))?;
+
+					::color_eyre::Result::Ok(())
+				})
+		}
+	}
+	.into()
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -87,11 +87,12 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
 		error!(argument_type.path, "Invalid argument type. Expected `Context`.");
 	}
 
+	let test_name = &function.sig.ident;
 	let inner_fn = &function.block;
 
 	quote! {
 		#[test]
-		fn balls() -> ::color_eyre::Result<()> {
+		fn #test_name() -> ::color_eyre::Result<()> {
 			use ::color_eyre::eyre::Context as _;
 			use ::sqlx::migrate::MigrateDatabase as _;
 			use ::std::fmt::Write as _;


### PR DESCRIPTION
This PR adds a custom proc-macro used to annotate test functions.

Every integration test gets its own API instance + temporary database.
Each database gets the same migrations as the prod instance, but extra scripts can be specified.

The simplest test looks like this:

```rust
#[crate::test]
async fn status(ctx: Context) {
    let schnose = ctx
        .client
        .get(ctx.url("/"))
        .send()
        .await?
        .text()
        .await?;

    assert_eq!(schnose, "(͡ ͡° ͜ つ ͡͡°)");
}
```

The macro actually doesn't care about the return type you specify; it will always be [`color_eyre::Result<()>`](https://docs.rs/eyre/0.6.11/eyre/type.Result.html).
Therefore the `?` operator can be used in all tests without much boilerplate and no `Ok(())` needs to be returned at the end.

If you want to apply extra scripts ("fixtures") to a test, you can list the file names as well:

```rust
#[crate::test("players.sql", "maps.sql")]
async fn my_test(ctx: Context) {
    // ...
}
```

The macro will look for those files in `./database/fixtures` (relative to the repository root).
Each of those files will also be checked at compile time using [`sqlx::query!`](https://docs.rs/sqlx/0.7.3/sqlx/macro.query.html).