### PR TITLE
Clean up Steam authentication

### DIFF
--- a/api-spec.json
+++ b/api-spec.json
@@ -1922,7 +1922,24 @@
         "summary": "This is where the frontend will redirect users to when they click \"login\".",
         "description": "This is where the frontend will redirect users to when they click \"login\".\nSteam will redirect them back to the API to confirm their identity.",
         "operationId": "login",
-        "responses": {}
+        "parameters": [
+          {
+            "name": "origin_url",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "303": {
+            "description": "This is a redirect."
+          },
+          "400": {
+            "description": "Required request data was missing / invalid."
+          }
+        }
       }
     },
     "/auth/steam/callback": {
@@ -1933,7 +1950,17 @@
         "summary": "This is where Steam will redirect a user back to after logging in.",
         "description": "This is where Steam will redirect a user back to after logging in.\nWe verify that the request actually comes from steam and give the user a cookie containing\na JWT.",
         "operationId": "callback",
-        "responses": {}
+        "responses": {
+          "303": {
+            "description": "This is a redirect."
+          },
+          "400": {
+            "description": "Required request data was missing / invalid."
+          },
+          "401": {
+            "description": "You do not have access to this resource."
+          }
+        }
       }
     }
   },

--- a/cs2kz-api/src/jwt.rs
+++ b/cs2kz-api/src/jwt.rs
@@ -1,6 +1,5 @@
 //! This module holds various types that are encoded into JWTs.
 
-use cs2kz::SteamID;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
@@ -29,23 +28,5 @@ impl ServerClaims {
 			plugin_version,
 			expires_at: jwt::get_current_timestamp() + (60 * 30),
 		}
-	}
-}
-
-/// Information about a user.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct UserClaims {
-	/// The user's SteamID.
-	pub steam_id: SteamID,
-
-	/// Timestamp of when this token expires.
-	#[serde(rename = "exp")]
-	pub expires_at: u64,
-}
-
-impl UserClaims {
-	/// Constructs a new token. It will expire after 1 day.
-	pub fn new(steam_id: SteamID) -> Self {
-		Self { steam_id, expires_at: jwt::get_current_timestamp() + (60 * 60 * 24) }
 	}
 }

--- a/cs2kz-api/src/openapi.rs
+++ b/cs2kz-api/src/openapi.rs
@@ -21,6 +21,10 @@ pub struct Created<T: ToSchema<'static> = ()>(#[to_schema] T);
 pub struct NoContent;
 
 #[derive(IntoResponses)]
+#[response(status = StatusCode::SEE_OTHER, description = "This is a redirect.")]
+pub struct Redirect;
+
+#[derive(IntoResponses)]
 #[response(status = StatusCode::BAD_REQUEST, description = "Required request data was missing / invalid.")]
 pub struct BadRequest;
 

--- a/cs2kz-api/src/steam.rs
+++ b/cs2kz-api/src/steam.rs
@@ -1,13 +1,17 @@
 //! This module holds structs specific to communication with the Steam API.
 
 use cs2kz::SteamID;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
+use tracing::trace;
 use url::Url;
 
+use crate::{Error, Result};
+
 static CALLBACK_ROUTE: &str = "/auth/steam/callback";
+static STEAM_LOGIN_VERIFY_URL: &str = "https://steamcommunity.com/openid/login";
 
 /// This is the data we send to Steam when redirecting a user to login.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RedirectForm {
 	#[serde(rename = "openid.ns")]
 	ns: &'static str,
@@ -25,7 +29,7 @@ pub struct RedirectForm {
 	callback_host: Url,
 
 	#[serde(rename = "openid.return_to")]
-	callback_url: Url,
+	pub(crate) callback_url: Url,
 }
 
 impl RedirectForm {
@@ -49,30 +53,95 @@ impl RedirectForm {
 /// This is what Steam sends after redirecting a user back to the API after their login.
 ///
 /// There are more fields here, technically, but we don't care about them.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AuthResponse {
-	/// The user's SteamID.
-	#[serde(rename = "openid.claimed_id", deserialize_with = "deser_steam_id")]
-	pub steam_id: SteamID,
+	/// The API's domain, if valid.
+	#[serde(rename = "openid.return_to")]
+	pub return_to: Url,
+
+	/// The original URL this request came from.
+	#[serde(skip_serializing)]
+	origin_url: Url,
+
+	#[serde(rename = "openid.mode")]
+	mode: String,
+
+	#[serde(rename = "openid.ns")]
+	ns: String,
+
+	#[serde(rename = "openid.op_endpoint")]
+	op_endpoint: String,
+
+	#[serde(rename = "openid.claimed_id")]
+	claimed_id: Url,
+
+	#[serde(rename = "openid.identity")]
+	identity: Option<String>,
+
+	#[serde(rename = "openid.response_nonce")]
+	response_nonce: String,
+
+	#[serde(rename = "openid.invalidate_handle")]
+	invalidate_handle: Option<String>,
+
+	#[serde(rename = "openid.assoc_handle")]
+	assoc_handle: String,
+
+	#[serde(rename = "openid.signed")]
+	signed: String,
+
+	#[serde(rename = "openid.sig")]
+	sig: String,
 }
 
-fn deser_steam_id<'de, D>(deserializer: D) -> Result<SteamID, D::Error>
-where
-	D: Deserializer<'de>,
-{
-	use serde::de::{Error as E, Unexpected as U};
+impl AuthResponse {
+	/// Extracts the claimed SteamID from the request body.
+	pub fn steam_id(&self) -> Result<SteamID> {
+		self.claimed_id
+			.path_segments()
+			.and_then(|segments| segments.last())
+			.and_then(|steam_id| steam_id.parse().ok())
+			.ok_or(Error::Unauthorized)
+	}
 
-	let url = Url::deserialize(deserializer)?;
-	let steam_id = url
-		.path_segments()
-		.ok_or(E::custom("missing SteamID from path"))?
-		.last()
-		.ok_or(E::custom("missing SteamID from path"))?;
+	/// Validates this response with Steam's API and extracts the claimed SteamID
+	/// and original request URL.
+	pub async fn validate(mut self, http_client: &reqwest::Client) -> Result<(SteamID, Url)> {
+		self.mode = String::from("check_authentication");
+		let query = serde_urlencoded::to_string(&self).expect("this is valid");
 
-	let steam_id = steam_id
-		.parse::<u64>()
-		.map_err(|_| E::invalid_type(U::Str(steam_id), &"64-bit SteamID"))?;
+		let response = http_client
+			.post(STEAM_LOGIN_VERIFY_URL)
+			.header("Content-Type", "application/x-www-form-urlencoded")
+			.body(query)
+			.send()
+			.await
+			.and_then(|res| res.error_for_status())
+			.map_err(|err| {
+				trace!(?err, "failed to authenticate user");
+				Error::Unauthorized
+			})?;
 
-	SteamID::from_u64(steam_id)
-		.map_err(|_| E::invalid_value(U::Unsigned(steam_id), &"64-bit SteamID"))
+		let body = response.text().await.map_err(|err| {
+			trace!(?err, "steam response was not text");
+			Error::Unauthorized
+		})?;
+
+		let is_valid = body
+			.lines()
+			.filter(|line| !line.is_empty())
+			.last()
+			.is_some_and(|line| line == "is_valid:true");
+
+		if !is_valid {
+			trace!("request was invalid");
+			return Err(Error::Unauthorized);
+		}
+
+		let steam_id = self.steam_id()?;
+
+		trace!(%steam_id, %self.origin_url, "user logged in with steam, verifying...");
+
+		Ok((steam_id, self.origin_url))
+	}
 }


### PR DESCRIPTION
- `/auth/steam/callback` requests are now verified properly
- origin url is included across requests, so we can redirect properly

TODO:
- create sessions and insert cookies
