### PR TITLE
Allow configuring a runtime environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,6 @@ TEST_DATABASE_URL=mysql://root:csgo-kz-is-dead-boys@127.0.0.1:8070/cs2kz
 RUST_LOG=cs2kz_api=trace,sqlx=debug,axum=trace,warn
 KZ_API_IP=127.0.0.1
 KZ_API_PORT=42069
-KZ_API_URL=https://cs2.kz
+KZ_API_URL=http://127.0.0.1:42069
 KZ_API_JWT_SECRET=Y3Nnby1rei1pcy1kZWFkLWJveXMK
+KZ_API_ENVIRONMENT=development

--- a/cs2kz-api/src/lib.rs
+++ b/cs2kz-api/src/lib.rs
@@ -145,11 +145,11 @@ impl API {
 	/// Starts an [`axum`] server to serve the API.
 	#[tracing::instrument]
 	pub async fn run(
-		config: Config,
+		Config { socket_addr, api_url, database_url, jwt_secret, environment }: Config,
 		database: MySqlPool,
 		tcp_listener: TcpListener,
 	) -> color_eyre::Result<()> {
-		let state = AppState::new(database, config.jwt_secret, config.api_url).await?;
+		let state = AppState::new(environment, database, jwt_secret, api_url).await?;
 
 		debug!("Initialized application state.");
 

--- a/cs2kz-api/src/routes/auth/steam.rs
+++ b/cs2kz-api/src/routes/auth/steam.rs
@@ -7,7 +7,7 @@ use axum::Router;
 use axum_extra::extract::cookie::Cookie;
 use axum_extra::extract::CookieJar;
 use serde::Deserialize;
-use tracing::trace;
+use tracing::{trace, warn};
 use url::{Host, Url};
 use utoipa::IntoParams;
 
@@ -79,6 +79,11 @@ pub async fn callback(
 					false
 				}
 			}
+		}
+
+		_ if state.in_dev() => {
+			warn!(%host, %public_host, "allowing invalid host due to dev mode");
+			true
 		}
 
 		_ => {


### PR DESCRIPTION
This introduces a new `environment` field in `cs2kz_api::State`, which
can be used to query whether we are currently running in production or
not.

Other changes related to this:

- If we are running in development, we allow logins on
  `/auth/steam/callback` from foreign hosts.
