### PR TITLE
Create session tokens and insert them as cookies

### DIFF
--- a/.sqlx/query-34e5479bcad16f091d7e0a007614562ea1f815afe3c18cce1e1f6b104afb5d86.json
+++ b/.sqlx/query-34e5479bcad16f091d7e0a007614562ea1f815afe3c18cce1e1f6b104afb5d86.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "\n\t\t\tINSERT INTO\n\t\t\t  WebSessions (subdomain, token, steam_id, expires_on)\n\t\t\tVALUES\n\t\t\t  (?, ?, ?, ?)\n\t\t\t",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": []
+  },
+  "hash": "34e5479bcad16f091d7e0a007614562ea1f815afe3c18cce1e1f6b104afb5d86"
+}

--- a/.sqlx/query-efa9d03872914f82de2d11700e047314d65a79a3168b1c24b8340c82bc005418.json
+++ b/.sqlx/query-efa9d03872914f82de2d11700e047314d65a79a3168b1c24b8340c82bc005418.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "\n\t\tSELECT\n\t\t  *\n\t\tFROM\n\t\t  Admins\n\t\tWHERE\n\t\t  steam_id = (\n\t\t    SELECT\n\t\t      steam_id\n\t\t    FROM\n\t\t      WebSessions\n\t\t    WHERE\n\t\t      token = ?\n\t\t      AND subdomain = ?\n\t\t      AND expires_on < CURRENT_TIMESTAMP()\n\t\t  )\n\t\t",
+  "query": "SELECT * FROM Admins WHERE steam_id = ?",
   "describe": {
     "columns": [
       {
@@ -25,12 +25,12 @@
       }
     ],
     "parameters": {
-      "Right": 2
+      "Right": 1
     },
     "nullable": [
       false,
       false
     ]
   },
-  "hash": "de853ae74c5782a63abcfc8acbf18c04756f19eaae8ada3ffef925643f0278fd"
+  "hash": "efa9d03872914f82de2d11700e047314d65a79a3168b1c24b8340c82bc005418"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,6 +2524,7 @@ dependencies = [
  "smallvec",
  "sqlformat",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2611,6 +2612,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -2652,6 +2654,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -2675,6 +2678,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
+ "time",
  "tracing",
  "url",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ features = ["macros", "net", "rt", "rt-multi-thread"]
 [workspace.dependencies.sqlx]
 version = "0.7"
 default-features = false
-features = ["macros", "runtime-tokio-rustls", "mysql", "chrono", "rust_decimal"]
+features = ["macros", "runtime-tokio-rustls", "mysql", "chrono", "time", "rust_decimal"]
 
 [workspace.dependencies.serde]
 version = "1"

--- a/api-spec.json
+++ b/api-spec.json
@@ -449,7 +449,7 @@
                     "name",
                     "mappers",
                     "courses",
-                    "checksum",
+                    "filesize",
                     "created_on",
                     "updated_on"
                   ],
@@ -484,10 +484,10 @@
                       },
                       "description": "List of courses on this map."
                     },
-                    "checksum": {
+                    "filesize": {
                       "type": "integer",
-                      "format": "uint32",
-                      "description": "The checksum of this map.",
+                      "format": "uint64",
+                      "description": "The filesize of this map in bytes.",
                       "minimum": 0
                     },
                     "created_on": {
@@ -502,7 +502,6 @@
                     }
                   },
                   "example": {
-                    "checksum": 190335000,
                     "courses": [
                       {
                         "filters": [
@@ -532,6 +531,7 @@
                       }
                     ],
                     "created_on": "2023-12-10T10:41:01Z",
+                    "filesize": 190335000,
                     "id": 1,
                     "mappers": [
                       {
@@ -652,7 +652,7 @@
                     "name",
                     "mappers",
                     "courses",
-                    "checksum",
+                    "filesize",
                     "created_on",
                     "updated_on"
                   ],
@@ -687,10 +687,10 @@
                       },
                       "description": "List of courses on this map."
                     },
-                    "checksum": {
+                    "filesize": {
                       "type": "integer",
-                      "format": "uint32",
-                      "description": "The checksum of this map.",
+                      "format": "uint64",
+                      "description": "The filesize of this map in bytes.",
                       "minimum": 0
                     },
                     "created_on": {
@@ -705,7 +705,6 @@
                     }
                   },
                   "example": {
-                    "checksum": 190335000,
                     "courses": [
                       {
                         "filters": [
@@ -735,6 +734,7 @@
                       }
                     ],
                     "created_on": "2023-12-10T10:41:01Z",
+                    "filesize": 190335000,
                     "id": 1,
                     "mappers": [
                       {
@@ -858,7 +858,7 @@
                     "name",
                     "mappers",
                     "courses",
-                    "checksum",
+                    "filesize",
                     "created_on",
                     "updated_on"
                   ],
@@ -893,10 +893,10 @@
                       },
                       "description": "List of courses on this map."
                     },
-                    "checksum": {
+                    "filesize": {
                       "type": "integer",
-                      "format": "uint32",
-                      "description": "The checksum of this map.",
+                      "format": "uint64",
+                      "description": "The filesize of this map in bytes.",
                       "minimum": 0
                     },
                     "created_on": {
@@ -911,7 +911,6 @@
                     }
                   },
                   "example": {
-                    "checksum": 190335000,
                     "courses": [
                       {
                         "filters": [
@@ -941,6 +940,7 @@
                       }
                     ],
                     "created_on": "2023-12-10T10:41:01Z",
+                    "filesize": 190335000,
                     "id": 1,
                     "mappers": [
                       {
@@ -3095,7 +3095,7 @@
           "name",
           "mappers",
           "courses",
-          "checksum",
+          "filesize",
           "created_on",
           "updated_on"
         ],
@@ -3130,10 +3130,10 @@
             },
             "description": "List of courses on this map."
           },
-          "checksum": {
+          "filesize": {
             "type": "integer",
-            "format": "uint32",
-            "description": "The checksum of this map.",
+            "format": "uint64",
+            "description": "The filesize of this map in bytes.",
             "minimum": 0
           },
           "created_on": {
@@ -3148,7 +3148,6 @@
           }
         },
         "example": {
-          "checksum": 190335000,
           "courses": [
             {
               "filters": [
@@ -3178,6 +3177,7 @@
             }
           ],
           "created_on": "2023-12-10T10:41:01Z",
+          "filesize": 190335000,
           "id": 1,
           "mappers": [
             {
@@ -3582,6 +3582,14 @@
             "description": "The map's new Steam Workshop ID.",
             "nullable": true,
             "minimum": 0
+          },
+          "name": {
+            "type": "boolean",
+            "description": "Update the map's name to the Workshop's version."
+          },
+          "filesize": {
+            "type": "boolean",
+            "description": "Update the map's filesize to the Workshop's value."
           },
           "added_mappers": {
             "type": "array",

--- a/cs2kz-api/src/extractors.rs
+++ b/cs2kz-api/src/extractors.rs
@@ -1,0 +1,41 @@
+//! Custom [extractors].
+//!
+//! [extractors]: axum::extract
+
+use axum::async_trait;
+use axum::extract::FromRequestParts;
+use axum::http::{header, request};
+use axum_extra::extract::cookie::Cookie;
+use time::OffsetDateTime;
+
+use crate::{AppState, Error, Result};
+
+/// A session token for logged in users.
+#[derive(Debug)]
+pub struct SessionToken(pub u64);
+
+#[async_trait]
+impl FromRequestParts<&'static AppState> for SessionToken {
+	type Rejection = Error;
+
+	async fn from_request_parts(parts: &mut request::Parts, _: &&'static AppState) -> Result<Self> {
+		parts
+			.headers
+			.get_all(header::COOKIE)
+			.into_iter()
+			.filter_map(|value| value.to_str().ok())
+			.flat_map(|value| value.split(';'))
+			.filter_map(|cookie| Cookie::parse_encoded(cookie.to_owned()).ok())
+			.find(|cookie| cookie.name() == "kz-auth" && !is_expired(cookie))
+			.and_then(|cookie| cookie.value().parse::<u64>().ok())
+			.map(Self)
+			.ok_or(Error::Unauthorized)
+	}
+}
+
+fn is_expired(cookie: &Cookie<'_>) -> bool {
+	match cookie.expires_datetime() {
+		None => false,
+		Some(datetime) => datetime < OffsetDateTime::now_utc(),
+	}
+}

--- a/cs2kz-api/src/lib.rs
+++ b/cs2kz-api/src/lib.rs
@@ -38,6 +38,7 @@ pub mod serde;
 pub mod sql;
 pub mod steam;
 pub mod permissions;
+pub mod extractors;
 
 pub mod responses;
 pub mod models;

--- a/cs2kz-api/src/permissions.rs
+++ b/cs2kz-api/src/permissions.rs
@@ -16,6 +16,22 @@ use serde::{Deserialize, Serialize};
 pub struct Permissions(pub u64);
 
 impl Permissions {
+	/// The base permissions.
+	pub const NONE: Self = Self(0);
+
+	/// Permissions allowed for dashboard.cs2.kz
+	pub const DASHBOARD: Self = Self(
+		Self::MAPS_ADD.0
+			| Self::MAPS_EDIT.0
+			| Self::MAPS_DELETE.0
+			| Self::SERVERS_INVALIDATE.0
+			| Self::SERVERS_ADD.0
+			| Self::SERVERS_EDIT.0
+			| Self::BANS_ADD.0
+			| Self::BANS_EDIT.0
+			| Self::GLOBAL_ADMIN.0,
+	);
+
 	/// Determines whether `permissions` is a subset of `self`.
 	pub const fn contains(&self, permissions: Self) -> bool {
 		self.0 & permissions.0 == permissions.0

--- a/database/migrations/20231228222205_permissions.up.sql
+++ b/database/migrations/20231228222205_permissions.up.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS Admins (
 	`steam_id` INT4 UNSIGNED NOT NULL,
 	`permissions` INT8 UNSIGNED NOT NULL,
 	PRIMARY KEY (`steam_id`, `permissions`),
-	FOREIGN KEY (`steam_id`) REFERENCES Players (`steam_id`)
+	FOREIGN KEY (`steam_id`) REFERENCES Players (`steam_id`),
+	UNIQUE(`steam_id`)
 );
 
 /**


### PR DESCRIPTION
When a user logs in with Steam, we create one session for each frontend and
insert them all as cookies. We also insert cookies with the user's SteamID and
permissions, which are available to JavaScript.
