### PR TITLE
Basic `/records` routes

### DIFF
--- a/.sqlx/query-0820d029773e60994430e0fd87cb356fd43d4c26d5758cc075dc6cac9b90fd98.json
+++ b/.sqlx/query-0820d029773e60994430e0fd87cb356fd43d4c26d5758cc075dc6cac9b90fd98.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "MySQL",
+  "query": "\n\t\t\t\tSELECT\n\t\t\t\t  id\n\t\t\t\tFROM\n\t\t\t\t  Maps\n\t\t\t\tWHERE\n\t\t\t\t  name LIKE ?\n\t\t\t\t",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "Short",
+          "flags": "NOT_NULL | PRIMARY_KEY | UNSIGNED | AUTO_INCREMENT",
+          "char_set": 63,
+          "max_size": 5
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0820d029773e60994430e0fd87cb356fd43d4c26d5758cc075dc6cac9b90fd98"
+}

--- a/.sqlx/query-5034ab60ecd61ab692e056c96666829f935017bf3cb8a9eea2ea10c6a53f58b0.json
+++ b/.sqlx/query-5034ab60ecd61ab692e056c96666829f935017bf3cb8a9eea2ea10c6a53f58b0.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "MySQL",
+  "query": "\n\t\tSELECT\n\t\t  id\n\t\tFROM\n\t\t  CourseFilters\n\t\tWHERE\n\t\t  course_id = ?\n\t\t  AND mode_id = ?\n\t\t  AND teleports = ?\n\t\t",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "Long",
+          "flags": "NOT_NULL | PRIMARY_KEY | UNSIGNED | AUTO_INCREMENT",
+          "char_set": 63,
+          "max_size": 10
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5034ab60ecd61ab692e056c96666829f935017bf3cb8a9eea2ea10c6a53f58b0"
+}

--- a/.sqlx/query-f84c3f6e9f4c52e2dc408d4ea5bf1b2c13afa51209bff292e926ddb95edc2e70.json
+++ b/.sqlx/query-f84c3f6e9f4c52e2dc408d4ea5bf1b2c13afa51209bff292e926ddb95edc2e70.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "\n\t\tINSERT INTO\n\t\t  Records (\n\t\t    player_id,\n\t\t    filter_id,\n\t\t    style_id,\n\t\t    teleports,\n\t\t    time,\n\t\t    server_id,\n\t\t    perfs,\n\t\t    bhops_tick0,\n\t\t    bhops_tick1,\n\t\t    bhops_tick2,\n\t\t    bhops_tick3,\n\t\t    bhops_tick4,\n\t\t    bhops_tick5,\n\t\t    bhops_tick6,\n\t\t    bhops_tick7,\n\t\t    bhops_tick8,\n\t\t    plugin_version_id\n\t\t  )\n\t\tVALUES\n\t\t  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n\t\t",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 17
+    },
+    "nullable": []
+  },
+  "hash": "f84c3f6e9f4c52e2dc408d4ea5bf1b2c13afa51209bff292e926ddb95edc2e70"
+}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,7 +10,7 @@ alias = "build"
 category = "Tools"
 description = "clippy"
 command = "cargo"
-args = ["clippy", "--all-features", "--tests"]
+args = ["clippy", "--all-features", "--tests", "${@}"]
 
 [tasks.fmt]
 category = "Tools"

--- a/api-spec.json
+++ b/api-spec.json
@@ -852,6 +852,335 @@
         ]
       }
     },
+    "/records": {
+      "get": {
+        "tags": [
+          "Records"
+        ],
+        "operationId": "get_many",
+        "parameters": [
+          {
+            "name": "player",
+            "in": "query",
+            "description": "Filter by a specific player.",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PlayerIdentifier"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "name": "map",
+            "in": "query",
+            "description": "Filter by a specific map.",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/MapIdentifier"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "name": "server",
+            "in": "query",
+            "description": "Filter by a specific server.",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ServerIdentifier"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Only include sessions after this timestamp.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "Only include sessions before this timestamp.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum amount of results.",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Offset used for pagination.",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "player",
+                    "map",
+                    "server",
+                    "mode",
+                    "style",
+                    "teleports",
+                    "time",
+                    "bhop_stats",
+                    "plugin_version",
+                    "created_on"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "description": "The record's ID.",
+                      "minimum": 0
+                    },
+                    "player": {
+                      "$ref": "#/components/schemas/Player"
+                    },
+                    "map": {
+                      "$ref": "#/components/schemas/MapInfo"
+                    },
+                    "server": {
+                      "$ref": "#/components/schemas/ServerInfo"
+                    },
+                    "mode": {
+                      "$ref": "#/components/schemas/Mode"
+                    },
+                    "style": {
+                      "$ref": "#/components/schemas/Style"
+                    },
+                    "teleports": {
+                      "type": "integer",
+                      "format": "uint16",
+                      "description": "The amount of teleports used during this run.",
+                      "minimum": 0
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "double",
+                      "description": "The time it took to complete this run."
+                    },
+                    "bhop_stats": {
+                      "$ref": "#/components/schemas/BhopStats"
+                    },
+                    "plugin_version": {
+                      "type": "string",
+                      "description": "The CS2KZ plugin version this run was performed on."
+                    },
+                    "created_on": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When this run was submitted."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "500": {
+            "description": "Something unexpected happened. This is a bug; please report it."
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Records"
+        ],
+        "operationId": "create",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewRecord"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "record_id"
+                  ],
+                  "properties": {
+                    "record_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "401": {
+            "description": ""
+          },
+          "422": {
+            "description": ""
+          },
+          "500": {
+            "description": "Something unexpected happened. This is a bug; please report it."
+          }
+        },
+        "security": [
+          {
+            "CS2 Server JWT": []
+          }
+        ]
+      }
+    },
+    "/records/{record_id}": {
+      "get": {
+        "tags": [
+          "Records"
+        ],
+        "operationId": "get_single",
+        "parameters": [
+          {
+            "name": "record_id",
+            "in": "path",
+            "description": "The record's ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "player",
+                    "map",
+                    "server",
+                    "mode",
+                    "style",
+                    "teleports",
+                    "time",
+                    "bhop_stats",
+                    "plugin_version",
+                    "created_on"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "description": "The record's ID.",
+                      "minimum": 0
+                    },
+                    "player": {
+                      "$ref": "#/components/schemas/Player"
+                    },
+                    "map": {
+                      "$ref": "#/components/schemas/MapInfo"
+                    },
+                    "server": {
+                      "$ref": "#/components/schemas/ServerInfo"
+                    },
+                    "mode": {
+                      "$ref": "#/components/schemas/Mode"
+                    },
+                    "style": {
+                      "$ref": "#/components/schemas/Style"
+                    },
+                    "teleports": {
+                      "type": "integer",
+                      "format": "uint16",
+                      "description": "The amount of teleports used during this run.",
+                      "minimum": 0
+                    },
+                    "time": {
+                      "type": "number",
+                      "format": "double",
+                      "description": "The time it took to complete this run."
+                    },
+                    "bhop_stats": {
+                      "$ref": "#/components/schemas/BhopStats"
+                    },
+                    "plugin_version": {
+                      "type": "string",
+                      "description": "The CS2KZ plugin version this run was performed on."
+                    },
+                    "created_on": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When this run was submitted."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "500": {
+            "description": "Something unexpected happened. This is a bug; please report it."
+          }
+        }
+      }
+    },
     "/players": {
       "get": {
         "tags": [
@@ -2894,6 +3223,19 @@
           }
         }
       },
+      "CreatedRecord": {
+        "type": "object",
+        "required": [
+          "record_id"
+        ],
+        "properties": {
+          "record_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        }
+      },
       "CreatedServer": {
         "type": "object",
         "description": "A newly approved KZ server.\n\nSee [`NewServer`].",
@@ -3147,6 +3489,23 @@
           }
         ]
       },
+      "MapInfo": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "MapUpdate": {
         "type": "object",
         "description": "Request body for updates to a map.",
@@ -3358,6 +3717,46 @@
           }
         }
       },
+      "NewRecord": {
+        "type": "object",
+        "required": [
+          "course_id",
+          "steam_id",
+          "mode",
+          "style",
+          "teleports",
+          "time",
+          "bhop_stats"
+        ],
+        "properties": {
+          "course_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "steam_id": {
+            "$ref": "#/components/schemas/SteamID"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/Mode"
+          },
+          "style": {
+            "$ref": "#/components/schemas/Style"
+          },
+          "teleports": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "time": {
+            "type": "number",
+            "format": "double"
+          },
+          "bhop_stats": {
+            "$ref": "#/components/schemas/BhopStats"
+          }
+        }
+      },
       "NewServer": {
         "type": "object",
         "description": "Request body for newly approved servers.",
@@ -3515,6 +3914,68 @@
           "ranked"
         ]
       },
+      "Record": {
+        "type": "object",
+        "required": [
+          "id",
+          "player",
+          "map",
+          "server",
+          "mode",
+          "style",
+          "teleports",
+          "time",
+          "bhop_stats",
+          "plugin_version",
+          "created_on"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "uint64",
+            "description": "The record's ID.",
+            "minimum": 0
+          },
+          "player": {
+            "$ref": "#/components/schemas/Player"
+          },
+          "map": {
+            "$ref": "#/components/schemas/MapInfo"
+          },
+          "server": {
+            "$ref": "#/components/schemas/ServerInfo"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/Mode"
+          },
+          "style": {
+            "$ref": "#/components/schemas/Style"
+          },
+          "teleports": {
+            "type": "integer",
+            "format": "uint16",
+            "description": "The amount of teleports used during this run.",
+            "minimum": 0
+          },
+          "time": {
+            "type": "number",
+            "format": "double",
+            "description": "The time it took to complete this run."
+          },
+          "bhop_stats": {
+            "$ref": "#/components/schemas/BhopStats"
+          },
+          "plugin_version": {
+            "type": "string",
+            "description": "The CS2KZ plugin version this run was performed on."
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this run was submitted."
+          }
+        }
+      },
       "Role": {
         "type": "string",
         "description": "The available roles as a descriptive enum.",
@@ -3577,6 +4038,23 @@
             "type": "string"
           }
         ]
+      },
+      "ServerInfo": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          }
+        }
       },
       "ServerUpdate": {
         "type": "object",

--- a/src/course_sessions/models.rs
+++ b/src/course_sessions/models.rs
@@ -8,7 +8,7 @@ use sqlx::{FromRow, Row};
 use utoipa::ToSchema;
 
 use crate::players::Player;
-use crate::sessions::models::BhopStats;
+use crate::records::models::BhopStats;
 
 /// Response body for course sessions.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]

--- a/src/course_sessions/queries.rs
+++ b/src/course_sessions/queries.rs
@@ -1,3 +1,4 @@
+/// Base query for `SELECT`ing course sessions from the database.
 pub static BASE_SELECT: &str = r#"
 	SELECT
 	  s.id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,13 @@ mod sessions;
       servers::models::CreatedServer,
       servers::models::ServerUpdate,
 
+      records::models::Record,
+      records::models::MapInfo,
+      records::models::ServerInfo,
+      records::models::NewRecord,
+      records::models::CreatedRecord,
+      records::models::BhopStats,
+
       players::models::Player,
       players::models::FullPlayer,
       players::models::NewPlayer,
@@ -164,7 +171,6 @@ mod sessions;
 
       sessions::models::Session,
       sessions::models::TimeSpent,
-      sessions::models::BhopStats,
 
       course_sessions::models::CourseSession,
     ),
@@ -183,6 +189,10 @@ mod sessions;
     servers::routes::update::update,
     servers::routes::replace_key::replace_key,
     servers::routes::delete_key::delete_key,
+
+    records::routes::get_many::get_many,
+    records::routes::create::create,
+    records::routes::get_single::get_single,
 
     players::routes::get_many::get_many,
     players::routes::create::create,

--- a/src/players/models.rs
+++ b/src/players/models.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
 
-use crate::sessions::models::{BhopStats, TimeSpent};
+use crate::records::models::BhopStats;
+use crate::sessions::models::TimeSpent;
 
 /// Basic information about a KZ player.
 ///

--- a/src/records.rs
+++ b/src/records.rs
@@ -1,9 +1,28 @@
+use axum::http::Method;
+use axum::routing::{get, post};
 use axum::Router;
 
-use crate::State;
+use crate::{cors, State};
+
+mod queries;
+
+pub mod models;
+pub use models::{CreatedRecord, NewRecord, Record};
 
 pub mod routes;
 
 pub fn router(state: &'static State) -> Router {
-	Router::new().with_state(state)
+	let root = Router::new()
+		.route("/", get(routes::get_many))
+		.route_layer(cors::permissive(Method::GET))
+		// TODO: AC middleware
+		.route("/", post(routes::create))
+		.with_state(state);
+
+	let ident = Router::new()
+		.route("/:record_id", get(routes::get_single))
+		.route_layer(cors::permissive(Method::GET))
+		.with_state(state);
+
+	root.merge(ident)
 }

--- a/src/records/models.rs
+++ b/src/records/models.rs
@@ -1,0 +1,145 @@
+use chrono::{DateTime, Utc};
+use cs2kz::{Mode, SteamID, Style};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sqlx::mysql::MySqlRow;
+use sqlx::{FromRow, Row};
+use utoipa::ToSchema;
+
+use crate::players::Player;
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct Record {
+	/// The record's ID.
+	pub id: u64,
+
+	/// The player who performed this run.
+	pub player: Player,
+
+	/// The map this run was performed on.
+	pub map: MapInfo,
+
+	/// The server this run was performed on.
+	pub server: ServerInfo,
+
+	/// The mode this run was performed in.
+	pub mode: Mode,
+
+	/// The style this run was performed in.
+	pub style: Style,
+
+	/// The amount of teleports used during this run.
+	pub teleports: u16,
+
+	/// The time it took to complete this run.
+	pub time: f64,
+
+	/// Bhop statistics.
+	pub bhop_stats: BhopStats,
+
+	/// The CS2KZ plugin version this run was performed on.
+	#[schema(value_type = String)]
+	pub plugin_version: Version,
+
+	/// When this run was submitted.
+	pub created_on: DateTime<Utc>,
+}
+
+impl FromRow<'_, MySqlRow> for Record {
+	fn from_row(row: &MySqlRow) -> sqlx::Result<Self> {
+		let id = row.try_get("id")?;
+		let player = Player {
+			steam_id: row.try_get("player_id")?,
+			name: row.try_get("player_name")?,
+		};
+
+		let map = MapInfo { id: row.try_get("map_id")?, name: row.try_get("map_name")? };
+
+		let server =
+			ServerInfo { id: row.try_get("server_id")?, name: row.try_get("server_name")? };
+
+		let mode = row.try_get("mode")?;
+		let style = row.try_get("style")?;
+		let teleports = row.try_get("teleports")?;
+		let time = row.try_get("time")?;
+
+		let bhop_stats = BhopStats {
+			perfs: row.try_get("perfs")?,
+			tick0: row.try_get("bhops_tick0")?,
+			tick1: row.try_get("bhops_tick1")?,
+			tick2: row.try_get("bhops_tick2")?,
+			tick3: row.try_get("bhops_tick3")?,
+			tick4: row.try_get("bhops_tick4")?,
+			tick5: row.try_get("bhops_tick5")?,
+			tick6: row.try_get("bhops_tick6")?,
+			tick7: row.try_get("bhops_tick7")?,
+			tick8: row.try_get("bhops_tick8")?,
+		};
+
+		let plugin_version = row
+			.try_get::<&str, _>("plugin_version")?
+			.parse::<Version>()
+			.map_err(|err| sqlx::Error::ColumnDecode {
+				index: String::from("plugin_version"),
+				source: Box::new(err),
+			})?;
+
+		let created_on = row.try_get("created_on")?;
+
+		Ok(Self {
+			id,
+			player,
+			map,
+			server,
+			mode,
+			style,
+			teleports,
+			time,
+			bhop_stats,
+			plugin_version,
+			created_on,
+		})
+	}
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MapInfo {
+	pub id: u16,
+	pub name: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ServerInfo {
+	pub id: u16,
+	pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct BhopStats {
+	pub perfs: u16,
+	pub tick0: u16,
+	pub tick1: u16,
+	pub tick2: u16,
+	pub tick3: u16,
+	pub tick4: u16,
+	pub tick5: u16,
+	pub tick6: u16,
+	pub tick7: u16,
+	pub tick8: u16,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct NewRecord {
+	pub course_id: u32,
+	pub steam_id: SteamID,
+	pub mode: Mode,
+	pub style: Style,
+	pub teleports: u16,
+	pub time: f64,
+	pub bhop_stats: BhopStats,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CreatedRecord {
+	pub record_id: u64,
+}

--- a/src/records/queries.rs
+++ b/src/records/queries.rs
@@ -1,0 +1,35 @@
+/// Base query for `SELECT`ing records from the database.
+pub static BASE_SELECT: &str = r#"
+	SELECT
+	  r.id,
+	  p.steam_id player_id,
+	  p.name player_name,
+	  m.id map_id,
+	  m.name map_name,
+	  s.id server_id,
+	  s.name server_name,
+	  f.mode_id MODE,
+	  r.style_id style,
+	  r.teleports,
+	  r.time,
+	  r.perfs,
+	  r.bhops_tick0,
+	  r.bhops_tick1,
+	  r.bhops_tick2,
+	  r.bhops_tick3,
+	  r.bhops_tick4,
+	  r.bhops_tick5,
+	  r.bhops_tick6,
+	  r.bhops_tick7,
+	  r.bhops_tick8,
+	  v.version plugin_version,
+	  r.created_on
+	FROM
+	  Records r
+	  JOIN Players p ON p.steam_id = r.player_id
+	  JOIN CourseFilters f ON f.id = r.filter_id
+	  JOIN Courses c ON c.id = f.course_id
+	  JOIN Maps m ON m.id = c.map_id
+	  JOIN Servers s ON s.id = r.server_id
+	  JOIN PluginVersions v ON v.id = r.plugin_version_id
+"#;

--- a/src/records/routes.rs
+++ b/src/records/routes.rs
@@ -1,1 +1,8 @@
+pub mod get_many;
+pub use get_many::get_many;
 
+pub mod create;
+pub use create::create;
+
+pub mod get_single;
+pub use get_single::get_single;

--- a/src/records/routes/create.rs
+++ b/src/records/routes/create.rs
@@ -1,0 +1,102 @@
+use axum::Json;
+
+use crate::auth::{Jwt, Server};
+use crate::records::{CreatedRecord, NewRecord};
+use crate::responses::{self, Created};
+use crate::{query, AppState, Error, Result};
+
+#[tracing::instrument(skip(state))]
+#[utoipa::path(
+  post,
+  tag = "Records",
+  path = "/records",
+  responses(
+    responses::Created<CreatedRecord>,
+    responses::BadRequest,
+    responses::Unauthorized,
+    responses::UnprocessableEntity,
+    responses::InternalServerError,
+  ),
+  security(
+    ("CS2 Server JWT" = []),
+  ),
+)]
+pub async fn create(
+	state: AppState,
+	server: Jwt<Server>,
+	Json(record): Json<NewRecord>,
+) -> Result<Created<Json<CreatedRecord>>> {
+	let mut transaction = state.begin_transaction().await?;
+
+	let filter_id = sqlx::query! {
+		r#"
+		SELECT
+		  id
+		FROM
+		  CourseFilters
+		WHERE
+		  course_id = ?
+		  AND mode_id = ?
+		  AND teleports = ?
+		"#,
+		record.course_id,
+		record.mode,
+		record.teleports > 0,
+	}
+	.fetch_optional(transaction.as_mut())
+	.await?
+	.map(|row| row.id)
+	.ok_or(Error::invalid("course ID").with_detail(record.course_id))?;
+
+	sqlx::query! {
+		r#"
+		INSERT INTO
+		  Records (
+		    player_id,
+		    filter_id,
+		    style_id,
+		    teleports,
+		    time,
+		    server_id,
+		    perfs,
+		    bhops_tick0,
+		    bhops_tick1,
+		    bhops_tick2,
+		    bhops_tick3,
+		    bhops_tick4,
+		    bhops_tick5,
+		    bhops_tick6,
+		    bhops_tick7,
+		    bhops_tick8,
+		    plugin_version_id
+		  )
+		VALUES
+		  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		"#,
+		record.steam_id,
+		filter_id,
+		record.style,
+		record.teleports,
+		record.time,
+		server.id,
+		record.bhop_stats.perfs,
+		record.bhop_stats.tick0,
+		record.bhop_stats.tick1,
+		record.bhop_stats.tick2,
+		record.bhop_stats.tick3,
+		record.bhop_stats.tick4,
+		record.bhop_stats.tick5,
+		record.bhop_stats.tick6,
+		record.bhop_stats.tick7,
+		record.bhop_stats.tick8,
+		server.plugin_version_id,
+	}
+	.execute(transaction.as_mut())
+	.await?;
+
+	let record_id = query::last_insert_id::<u64>(transaction.as_mut()).await?;
+
+	transaction.commit().await?;
+
+	Ok(Created(Json(CreatedRecord { record_id })))
+}

--- a/src/records/routes/get_many.rs
+++ b/src/records/routes/get_many.rs
@@ -1,0 +1,107 @@
+use axum::extract::Query;
+use axum::Json;
+use chrono::{DateTime, Utc};
+use cs2kz::{MapIdentifier, PlayerIdentifier, ServerIdentifier};
+use serde::Deserialize;
+use utoipa::IntoParams;
+
+use crate::database::ToID;
+use crate::params::{Limit, Offset};
+use crate::query::{self, FilteredQuery};
+use crate::records::{queries, Record};
+use crate::{responses, AppState, Error, Result};
+
+#[derive(Debug, Default, Deserialize, IntoParams)]
+#[serde(default)]
+pub struct GetRecordsParams<'a> {
+	/// Filter by a specific player.
+	pub player: Option<PlayerIdentifier<'a>>,
+
+	/// Filter by a specific map.
+	pub map: Option<MapIdentifier<'a>>,
+
+	/// Filter by a specific server.
+	pub server: Option<ServerIdentifier<'a>>,
+
+	/// Only include sessions after this timestamp.
+	pub after: Option<DateTime<Utc>>,
+
+	/// Only include sessions before this timestamp.
+	pub before: Option<DateTime<Utc>>,
+
+	/// Maximum amount of results.
+	pub limit: Limit,
+
+	/// Offset used for pagination.
+	pub offset: Offset,
+}
+
+#[tracing::instrument(skip(state))]
+#[utoipa::path(
+  get,
+  tag = "Records",
+  path = "/records",
+  params(GetRecordsParams<'_>),
+  responses(
+    responses::Ok<Record>,
+    responses::NoContent,
+    responses::BadRequest,
+    responses::InternalServerError,
+  ),
+)]
+pub async fn get_many(
+	state: AppState,
+	Query(params): Query<GetRecordsParams<'_>>,
+) -> Result<Json<Vec<Record>>> {
+	let mut query = FilteredQuery::new(queries::BASE_SELECT);
+
+	if let Some(player) = params.player {
+		let steam_id = player.to_id(&state.database).await?;
+
+		query.filter(|query| {
+			query.push(" p.steam_id = ").push_bind(steam_id);
+		});
+	}
+
+	if let Some(map) = params.map {
+		let map_id = map.to_id(&state.database).await?;
+
+		query.filter(|query| {
+			query.push(" m.id = ").push_bind(map_id);
+		});
+	}
+
+	if let Some(server) = params.server {
+		let server_id = server.to_id(&state.database).await?;
+
+		query.filter(|query| {
+			query.push(" s.id = ").push_bind(server_id);
+		});
+	}
+
+	if let Some(after) = params.after {
+		query.filter(|query| {
+			query.push(" r.created_on > ").push_bind(after);
+		});
+	}
+
+	if let Some(before) = params.before {
+		query.filter(|query| {
+			query.push(" r.created_on < ").push_bind(before);
+		});
+	}
+
+	query.push(" ORDER BY r.id DESC ");
+	query::push_limit(params.limit, params.offset, &mut query);
+
+	let records = query
+		.build_query_as::<Record>()
+		.fetch_all(&state.database)
+		.await?;
+
+	if records.is_empty() {
+		return Err(Error::no_data());
+	}
+
+	Ok(Json(records))
+}

--- a/src/records/routes/get_single.rs
+++ b/src/records/routes/get_single.rs
@@ -1,0 +1,33 @@
+use axum::extract::Path;
+use axum::Json;
+
+use crate::query::FilteredQuery;
+use crate::records::{queries, Record};
+use crate::{responses, AppState, Error, Result};
+
+#[tracing::instrument(skip(state))]
+#[utoipa::path(
+  get,
+  tag = "Records",
+  path = "/records/{record_id}",
+  params(("record_id" = u64, Path, description = "The record's ID")),
+  responses(
+    responses::Ok<Record>,
+    responses::NoContent,
+    responses::BadRequest,
+    responses::InternalServerError,
+  ),
+)]
+pub async fn get_single(state: AppState, Path(record_id): Path<u64>) -> Result<Json<Record>> {
+	let mut query = FilteredQuery::new(queries::BASE_SELECT);
+
+	query.push(" WHERE r.id = ").push_bind(record_id);
+
+	let record = query
+		.build_query_as::<Record>()
+		.fetch_optional(&state.database)
+		.await?
+		.ok_or(Error::no_data())?;
+
+	Ok(Json(record))
+}

--- a/src/sessions/models.rs
+++ b/src/sessions/models.rs
@@ -8,6 +8,7 @@ use sqlx::{FromRow, Row};
 use utoipa::ToSchema;
 
 use crate::players::Player;
+use crate::records::models::BhopStats;
 use crate::servers::Server;
 
 /// Response body for player sessions.
@@ -103,18 +104,4 @@ pub struct TimeSpent {
 	#[serde(with = "crate::serde::duration::as_secs")]
 	#[schema(value_type = u16)]
 	pub afk: Duration,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-pub struct BhopStats {
-	pub perfs: u16,
-	pub tick0: u16,
-	pub tick1: u16,
-	pub tick2: u16,
-	pub tick3: u16,
-	pub tick4: u16,
-	pub tick5: u16,
-	pub tick6: u16,
-	pub tick7: u16,
-	pub tick8: u16,
 }

--- a/src/sessions/queries.rs
+++ b/src/sessions/queries.rs
@@ -1,3 +1,4 @@
+/// Base query for `SELECT`ing sessions from the database.
 pub static BASE_SELECT: &str = r#"
 	SELECT
 	  s.id,


### PR DESCRIPTION
This provides the first steps for CRUD operations on records (see #32).

Implemented routes:
- `GET /records`
- `GET /records/:id`
- `POST /records`

More sophisticated endpoints for retrieving leaderboards will be added in the future.