### PR TITLE
cs2kz: Respect `#` sigil when debug printing `Mode`

### DIFF
--- a/lib/cs2kz/src/mode/mod.rs
+++ b/lib/cs2kz/src/mode/mod.rs
@@ -22,7 +22,7 @@ mod tests;
 
 /// The two gamemodes officially supported by CS2KZ.
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Mode
 {
 	/// The VNL gamemode.
@@ -85,6 +85,17 @@ impl Mode
 			Self::Vanilla => "VNL",
 			Self::Classic => "CKZ",
 		}
+	}
+}
+
+impl fmt::Debug for Mode
+{
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
+	{
+		f.write_str(match f.alternate() {
+			false => self.as_str_short(),
+			true => self.as_str_capitalized(),
+		})
 	}
 }
 

--- a/lib/cs2kz/src/mode/tests.rs
+++ b/lib/cs2kz/src/mode/tests.rs
@@ -23,8 +23,15 @@ fn into_u8()
 #[test]
 fn parse_u8()
 {
-	assert_eq!("1".parse::<Mode>(), Ok(Mode::Vanilla));
-	assert_eq!("2".parse::<Mode>(), Ok(Mode::Classic));
+	for x in (u8::MIN..=u8::MAX).map(|x| x.to_string()) {
+		let result = x.parse::<Mode>();
+
+		match x.as_str() {
+			"1" => assert_eq!(result, Ok(Mode::Vanilla)),
+			"2" => assert_eq!(result, Ok(Mode::Classic)),
+			_ => assert!(result.is_err()),
+		}
+	}
 }
 
 #[test]
@@ -34,4 +41,13 @@ fn parse_str()
 	assert_eq!("vaNilLa".parse::<Mode>(), Ok(Mode::Vanilla));
 	assert_eq!("CKZ".parse::<Mode>(), Ok(Mode::Classic));
 	assert_eq!("classic".parse::<Mode>(), Ok(Mode::Classic));
+}
+
+#[test]
+fn fmt_debug()
+{
+	for mode in [Mode::Vanilla, Mode::Classic] {
+		assert_eq!(format!("{:?}", mode), mode.as_str_short());
+		assert_eq!(format!("{:#?}", mode), mode.as_str_capitalized());
+	}
 }


### PR DESCRIPTION
Previously, `cs2kz::Mode` would be debug-formatted using its full name, i.e. `Vanilla` / `Classic`.

This commit changes this to use an abbreviated form instead.
The previous long form can be opted into using the `#` sigil ("pretty printing").