### PR TITLE
Get rid of `chrono` and only use `time`

### DIFF
--- a/.sqlx/query-7fe2f7f591505bbb9165ada358fccbef364f8bee091271a04e1724cbb91a2eff.json
+++ b/.sqlx/query-7fe2f7f591505bbb9165ada358fccbef364f8bee091271a04e1724cbb91a2eff.json
@@ -1,11 +1,11 @@
 {
   "db_name": "MySQL",
-  "query": "\n\t\t\tSELECT\n\t\t\t  b.created_on `created_on: DateTime<Utc>`,\n\t\t\t  ub.id `unban_id: UnbanID`\n\t\t\tFROM\n\t\t\t  Bans b\n\t\t\t  LEFT JOIN Unbans ub ON ub.ban_id = b.id\n\t\t\tWHERE\n\t\t\t  b.id = ?\n\t\t\t",
+  "query": "\n\t\t\tSELECT\n\t\t\t  b.created_on `created_on: OffsetDateTime`,\n\t\t\t  ub.id `unban_id: UnbanID`\n\t\t\tFROM\n\t\t\t  Bans b\n\t\t\t  LEFT JOIN Unbans ub ON ub.ban_id = b.id\n\t\t\tWHERE\n\t\t\t  b.id = ?\n\t\t\t",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
-        "name": "created_on: DateTime<Utc>",
+        "name": "created_on: OffsetDateTime",
         "type_info": {
           "type": "Timestamp",
           "flags": "NOT_NULL | UNSIGNED | BINARY | TIMESTAMP",
@@ -30,5 +30,5 @@
       true
     ]
   },
-  "hash": "8ec3da010d46123743310ac1fff49f90332559b5ab103dc81d0fdb8a05d445e8"
+  "hash": "7fe2f7f591505bbb9165ada358fccbef364f8bee091271a04e1724cbb91a2eff"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,21 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,19 +339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "serde",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,12 +477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,7 +560,6 @@ version = "0.0.0"
 dependencies = [
  "axum",
  "axum-extra",
- "chrono",
  "clap",
  "color-eyre",
  "console-subscriber",
@@ -711,6 +676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1254,29 +1220,6 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2482,7 +2425,6 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
- "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -2568,7 +2510,6 @@ dependencies = [
  "bitflags 2.6.0",
  "byteorder",
  "bytes",
- "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -2612,7 +2553,6 @@ dependencies = [
  "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
- "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2650,7 +2590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
 dependencies = [
  "atoi",
- "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -3456,15 +3395,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ features = [
   "mysql",
   "migrate",
   "uuid",
-  "chrono",
   "time",
   "json",
 ]
@@ -111,7 +110,7 @@ version = "4.2"
 features = [
   "auto_into_responses",
   "axum_extras",
-  "chrono",
+  "time",
   "non_strict_integers",
   "preserve_order",
   "preserve_path_order",
@@ -144,13 +143,9 @@ version = "0.7"
 [dependencies.jsonwebtoken]
 version = "9.3"
 
-[dependencies.chrono]
-version = "0.4"
-default-features = false
-features = ["serde"]
-
 [dependencies.time]
 version = "0.3"
+features = ["serde-human-readable"]
 
 [dependencies.url]
 version = "2.5"

--- a/src/services/auth/jwt/mod.rs
+++ b/src/services/auth/jwt/mod.rs
@@ -13,9 +13,9 @@ use axum::{async_trait, RequestPartsExt};
 use axum_extra::headers::authorization::Bearer;
 use axum_extra::headers::Authorization;
 use axum_extra::TypedHeader;
-use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 use crate::services::AuthService;
 
@@ -84,12 +84,12 @@ impl<T> Jwt<T>
 		self.expiration_timestamp
 	}
 
-	/// Returns a [`chrono::DateTime`] of when this token will expire.
-	pub fn expires_on(&self) -> DateTime<Utc>
+	/// Returns a [`time::OffsetDateTime`] of when this token will expire.
+	pub fn expires_on(&self) -> OffsetDateTime
 	{
 		let secs = i64::try_from(self.expiration_timestamp).expect("sensible expiration date");
 
-		DateTime::from_timestamp(secs, 0).expect("valid expiration date")
+		OffsetDateTime::from_unix_timestamp(secs).expect("valid expiration date")
 	}
 
 	/// Checks if this token has expired.
@@ -107,7 +107,7 @@ where
 	{
 		f.debug_struct("Jwt")
 			.field("payload", self.payload())
-			.field("expires_on", &format_args!("{}", self.expires_on().format("%Y/%m/%d %H:%M:%S")))
+			.field("expires_on", &self.expires_on())
 			.finish()
 	}
 }

--- a/src/services/bans/http.rs
+++ b/src/services/bans/http.rs
@@ -2,9 +2,9 @@
 
 use axum::extract::State;
 use axum::{routing, Router};
-use chrono::{DateTime, Utc};
 use cs2kz::SteamID;
 use serde::Deserialize;
+use time::OffsetDateTime;
 use tower::ServiceBuilder;
 
 use super::models::UnbanReason;
@@ -169,7 +169,8 @@ pub(crate) struct UpdateBanRequestPayload
 	new_reason: Option<String>,
 
 	/// A new expiration date.
-	new_expiration_date: Option<DateTime<Utc>>,
+	#[serde(default, with = "time::serde::rfc3339::option")]
+	new_expiration_date: Option<OffsetDateTime>,
 }
 
 /// Update a ban.

--- a/src/services/bans/mod.rs
+++ b/src/services/bans/mod.rs
@@ -10,9 +10,9 @@ use std::fmt;
 use std::time::Duration;
 
 use axum::extract::FromRef;
-use chrono::{DateTime, Utc};
 use cs2kz::SteamID;
 use sqlx::{MySql, Pool, Row, Transaction};
+use time::OffsetDateTime;
 
 use crate::database::{SqlErrorExt, TransactionExt};
 use crate::net::IpAddr;
@@ -198,7 +198,7 @@ impl BanService
 		let (created_on, unban_id) = sqlx::query! {
 			r"
 			SELECT
-			  b.created_on `created_on: DateTime<Utc>`,
+			  b.created_on `created_on: OffsetDateTime`,
 			  ub.id `unban_id: UnbanID`
 			FROM
 			  Bans b
@@ -496,7 +496,7 @@ async fn create_ban(
 		reason,
 		banned_by_details.admin_id,
 		banned_by_details.plugin_version_id,
-		Utc::now() + ban_duration,
+		OffsetDateTime::now_utc() + ban_duration,
 	}
 	.fetch_one(txn.as_mut())
 	.await

--- a/src/services/jumpstats/models.rs
+++ b/src/services/jumpstats/models.rs
@@ -1,9 +1,9 @@
 //! Request / Response types for this service.
 
 use axum::response::{AppendHeaders, IntoResponse, Response};
-use chrono::{DateTime, Utc};
 use cs2kz::{JumpType, Mode, SteamID};
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 use crate::num::ClampedU64;
 use crate::services::players::PlayerInfo;
@@ -90,7 +90,8 @@ pub struct FetchJumpstatResponse
 	pub airtime: Seconds,
 
 	/// When this jumpstat was submitted.
-	pub created_on: DateTime<Utc>,
+	#[serde(with = "time::serde::rfc3339")]
+	pub created_on: OffsetDateTime,
 }
 
 impl IntoResponse for FetchJumpstatResponse
@@ -122,10 +123,12 @@ pub struct FetchJumpstatsRequest
 	pub server: Option<ServerIdentifier>,
 
 	/// Only include jumpstats submitted after this date.
-	pub created_after: Option<DateTime<Utc>>,
+	#[serde(default, with = "time::serde::rfc3339::option")]
+	pub created_after: Option<OffsetDateTime>,
 
 	/// Only include jumpstats submitted before this date.
-	pub created_before: Option<DateTime<Utc>>,
+	#[serde(default, with = "time::serde::rfc3339::option")]
+	pub created_before: Option<OffsetDateTime>,
 
 	/// Maximum number of results to return.
 	#[serde(default)]

--- a/src/services/plugin/models/mod.rs
+++ b/src/services/plugin/models/mod.rs
@@ -1,8 +1,8 @@
 //! Request / Response types for this service.
 
 use axum::response::{AppendHeaders, IntoResponse, Response};
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 use crate::num::ClampedU64;
 
@@ -86,7 +86,8 @@ pub struct FetchPluginVersionResponse
 	pub git_revision: String,
 
 	/// When this version was submitted.
-	pub created_on: DateTime<Utc>,
+	#[serde(with = "time::serde::rfc3339")]
+	pub created_on: OffsetDateTime,
 }
 
 impl IntoResponse for FetchPluginVersionResponse

--- a/src/services/records/models.rs
+++ b/src/services/records/models.rs
@@ -1,9 +1,9 @@
 //! Request / Response types for this service.
 
 use axum::response::{AppendHeaders, IntoResponse, Response};
-use chrono::{DateTime, Utc};
 use cs2kz::{Mode, RankedStatus, SteamID, Styles, Tier};
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 use crate::num::ClampedU64;
 use crate::services::maps::{CourseID, MapID};
@@ -64,7 +64,8 @@ pub struct FetchRecordResponse
 	pub bhop_stats: BhopStats,
 
 	/// When this record was submitted.
-	pub created_on: DateTime<Utc>,
+	#[serde(with = "time::serde::rfc3339")]
+	pub created_on: OffsetDateTime,
 }
 
 impl IntoResponse for FetchRecordResponse
@@ -149,10 +150,12 @@ pub struct FetchRecordsRequest
 	pub sort_by: SortRecordsBy,
 
 	/// Only include records submitted after this date.
-	pub created_after: Option<DateTime<Utc>>,
+	#[serde(default, with = "time::serde::rfc3339::option")]
+	pub created_after: Option<OffsetDateTime>,
 
 	/// Only include records submitted before this date.
-	pub created_before: Option<DateTime<Utc>>,
+	#[serde(default, with = "time::serde::rfc3339::option")]
+	pub created_before: Option<OffsetDateTime>,
 
 	/// The maximum amount of records to return.
 	#[serde(default)]

--- a/src/services/servers/models/mod.rs
+++ b/src/services/servers/models/mod.rs
@@ -1,9 +1,9 @@
 //! A service for managing KZ servers.
 
 use axum::response::{AppendHeaders, IntoResponse, Response};
-use chrono::{DateTime, Utc};
 use cs2kz::SteamID;
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 use crate::num::ClampedU64;
 use crate::services::plugin::PluginVersion;
@@ -66,7 +66,8 @@ pub struct FetchServerResponse
 	pub owner: ServerOwner,
 
 	/// When this server was approved.
-	pub created_on: DateTime<Utc>,
+	#[serde(with = "time::serde::rfc3339")]
+	pub created_on: OffsetDateTime,
 }
 
 impl IntoResponse for FetchServerResponse
@@ -104,10 +105,12 @@ pub struct FetchServersRequest
 	pub owned_by: Option<PlayerIdentifier>,
 
 	/// Filter by approval date.
-	pub created_after: Option<DateTime<Utc>>,
+	#[serde(default, with = "time::serde::rfc3339::option")]
+	pub created_after: Option<OffsetDateTime>,
 
 	/// Filter by approval date.
-	pub created_before: Option<DateTime<Utc>>,
+	#[serde(default, with = "time::serde::rfc3339::option")]
+	pub created_before: Option<OffsetDateTime>,
 
 	/// The maximum amount of servers to return.
 	#[serde(default)]


### PR DESCRIPTION
Using both is annoying, and all of our dependencies support `time`, but not everything supports `chrono`.

So let's just use `time` :)
